### PR TITLE
Enable creating multiple ssm-managed-instances dynamically

### DIFF
--- a/modules/agent-connectivity/versions.tf
+++ b/modules/agent-connectivity/versions.tf
@@ -1,13 +1,13 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.46.0"
+      version = ">= 3.13.0"
     }
     archive = {
       source  = "hashicorp/archive"
-      version = ">= 1.3.0"
+      version = ">= 2.2.0"
     }
   }
 }

--- a/modules/cloudwatch-agent/variables.tf
+++ b/modules/cloudwatch-agent/variables.tf
@@ -23,8 +23,7 @@ variable "log_group_name" {
 }
 
 variable "instance_identifier" {
-  description = "(Optional) An identifier to use for metric dimensions and log stream names for metrics and logs collected by the CloudWatch agent when using the default JSON configuration. (NOTE: A hardcoded value like `my-instance-name` can be used here if the module is being used to target only a single managed instance.)"
-  default     = "{local_hostname}"
+  description = "An identifier to use for metric dimensions and log stream names for metrics and logs collected by the CloudWatch agent when using the default JSON configuration. (NOTE: A hardcoded value like `my-instance-name` can be used here if the module is being used to target only a single managed instance.)"
 }
 
 variable "metric_namespace" {

--- a/modules/cloudwatch-agent/versions.tf
+++ b/modules/cloudwatch-agent/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.46.0"
+      version = ">= 3.13.0"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "activation_code_ssm_parameter_name" {
 }
 
 output "instance_name" {
-  value = local.instance_name
+  value = var.instance_name
 }
 
 output "role_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,6 @@ variable "name_prefix" {
 variable "instance_name" {
   description = "(Optional) A name to associate with the managed instance."
   type        = string
-  default     = ""
 }
 
 variable "instance_tags" {
@@ -29,11 +28,6 @@ variable "policy_arns" {
 variable "policy_statements" {
   description = "A list of policy statements to attach to the SSM service role."
   default     = []
-}
-
-variable "registration_limit" {
-  description = "The number of managed instances that can be registered using the SSM activation."
-  default     = 1
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 1.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Changelog core:
- Made instance_name mandatory
- Include instance_name in SSM path
- remove ability to register multiple instances with one activation.

Changelog module/cloudwatch-agent:
- Make instance_identifier mandatory
- Include instance_identifier in ssm path
- Include instance_identifier in metric_namespace
- Include instance_identifier in log_group_name

Changes enable simple modularization in end user modules.
By using for_each on a list of instance_names we can create a simplified module for creating and updating ssm-managed instances.

example usage of rollingstock module `ecs-anywhere-ssm-managed-instances`
```terraform
module "ecs_anywhere_ssm_managed_instances" {
  source               = "../modules/common/ecs-anywhere-ssm-managed-instances"
  name_prefix          = var.name_prefix
  tags                 = var.tags
  instance_names       = var.ecs_anywhere_server_names
  ecs_cluster_name     = aws_ecs_cluster.ecs_anywhere_cluster.name
}
```

- `ecs_cluster` name is inferred as `rollingstock-on-prem-cluster` for this example
- `instance_names` is defined as the following `[ "linuxserver452" ]` in the envirnment specific terraform code
- will in the background set up alarms pr instance and setup monitoring and triggering of the lambda from module/agent_connectivity


All modules should be capable of being instantiated multiple times and this module was not.
